### PR TITLE
>訂正した点（ホーム画面）

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -6,7 +6,6 @@
         <option name="distributionType" value="LOCAL" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
         <option name="gradleHome" value="C:\Program Files\Android\Android Studio\gradle\gradle-2.2.1" />
-        <option name="gradleJvm" value="1.8" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />
@@ -17,3 +16,4 @@
     </option>
   </component>
 </project>
+

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -10,3 +10,4 @@
     <option name="id" value="Android" />
   </component>
 </project>
+

--- a/Nichiwa-Sonaechao.iml
+++ b/Nichiwa-Sonaechao.iml
@@ -4,7 +4,6 @@
     <facet type="java-gradle" name="Java-Gradle">
       <configuration>
         <option name="BUILD_FOLDER_PATH" value="$MODULE_DIR$/build" />
-        <option name="BUILDABLE" value="false" />
       </configuration>
     </facet>
   </component>
@@ -17,3 +16,4 @@
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
 </module>
+

--- a/app/app.iml
+++ b/app/app.iml
@@ -12,9 +12,8 @@
         <option name="SELECTED_TEST_ARTIFACT" value="_android_test_" />
         <option name="ASSEMBLE_TASK_NAME" value="assembleDebug" />
         <option name="COMPILE_JAVA_TASK_NAME" value="compileDebugSources" />
-        <option name="SOURCE_GEN_TASK_NAME" value="generateDebugSources" />
         <option name="ASSEMBLE_TEST_TASK_NAME" value="assembleDebugAndroidTest" />
-        <option name="COMPILE_JAVA_TEST_TASK_NAME" value="compileDebugAndroidTestSources" />
+        <option name="SOURCE_GEN_TASK_NAME" value="generateDebugSources" />
         <option name="TEST_SOURCE_GEN_TASK_NAME" value="generateDebugAndroidTestSources" />
         <option name="ALLOW_USER_CONFIGURATION" value="false" />
         <option name="MANIFEST_FILE_RELATIVE_PATH" value="/src/main/AndroidManifest.xml" />
@@ -82,6 +81,7 @@
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/rs" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/symbols" />
       <excludeFolder url="file://$MODULE_DIR$/build/outputs" />
+      <excludeFolder url="file://$MODULE_DIR$/build/tmp" />
     </content>
     <orderEntry type="jdk" jdkName="Android API 21 Platform" jdkType="Android SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
@@ -110,3 +110,4 @@
     <orderEntry type="library" exported="" name="play-services-gcm-7.3.0" level="project" />
   </component>
 </module>
+

--- a/app/src/main/java/jp/co/nichiwa_system/yamashitamasaki/Sonaechao/MainActivity.java
+++ b/app/src/main/java/jp/co/nichiwa_system/yamashitamasaki/Sonaechao/MainActivity.java
@@ -231,7 +231,7 @@ public class MainActivity extends Activity {
         //備蓄品の割合が60%未満且つ、非常食が0ではない且つ、設定人数が0の場合、警告を出す。
         if( goukei[0] < 60 && !( volume[0] <= 0) && gou > 0)
         {
-            keikoku = new DialogClass("警告","非常食が60%未満です",this);
+            keikoku = new DialogClass("警告","　非常食が60%未満です",this);
             keikoku.setPositiveButton("確認する", new DialogInterface.OnClickListener() {
                 @Override
                 public void onClick(DialogInterface dialog, int which) {
@@ -248,7 +248,7 @@ public class MainActivity extends Activity {
         //非常食の割合が60%未満且つ、備蓄品が0ではない且つ、設定人数が0の場合、警告を出す
         if( goukei[1] < 60 && !( volume[1] <= 0 ) && gou > 0)
         {
-            keikoku = new DialogClass("警告","備蓄品が60%未満です",this);
+            keikoku = new DialogClass("警告","　備蓄品が60%未満です",this);
             keikoku.setPositiveButton("確認する", new DialogInterface.OnClickListener() {
                 @Override
                 public void onClick(DialogInterface dialog, int which) {
@@ -267,9 +267,9 @@ public class MainActivity extends Activity {
         if( gou <= 0 )
         {
             //ダイアログの表示
-            DialogClass dc = new DialogClass("警告！","設定画面から値を入力してください",this);
+            DialogClass dc = new DialogClass("警告！","　初期設定を行ってください",this);
             dc.setPositiveButton("設定へ移動", new ListenerClass("jp.co.nichiwa_system.yamashitamasaki.Sonaechao", "jp.co.nichiwa_system.yamashitamasaki.Sonaechao.SubActivity", MainActivity.this) );
-            dc.setNegativeButton("後で",null);
+//            dc.setNegativeButton("後で",null);
             dc.Diarog_show();
         }
 
@@ -283,6 +283,7 @@ public class MainActivity extends Activity {
         for( int i = 0 ; i < MAX_HIJOUSYOKU ; i++ ) {
             Hijousyoku_tv[i] = new TextView(this);
             //警告文を取得する
+            Hijousyoku_tv[i].setTextSize(18.0f);
             Hijousyoku_tv[i].setText(get_Number_of_days_Warning(item[i].getPrefName(), item[i].getName()));
             //警告文を挿入する
             if( Hijousyoku_tv[i].getText().length() > 0 ) {
@@ -380,10 +381,11 @@ public class MainActivity extends Activity {
     public String get_Number_of_days_Warning( String prefName, String HijousyokuName )
     {
         String str = "";
+
         //残り日数を取得する
         int nokori = (int)getDate(prefName);
         //期日を取得する
-        int nissu =  ( getSharedPreferences("Preferences",MODE_PRIVATE) ).getInt("kiniti_day",0);
+        int nissu =  ( getSharedPreferences("Preferences",MODE_PRIVATE) ).getInt("kiniti_day",14);
         if( nokori < 0 ) {
             //賞味期限が切れたら表示
             str = HijousyokuName + "の賞味期限が切れました";

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -38,7 +38,7 @@
         android:layout_height="wrap_content"
         android:textAppearance="?android:attr/textAppearanceMedium"
         android:gravity="center"
-        android:text="防災グッズ"
+        android:text="備蓄品"
         android:id="@+id/textView18"
         android:layout_alignTop="@+id/textView17"
         android:layout_alignEnd="@+id/R_graph"


### PR DESCRIPTION
> > 初期設定ダイアログの文章を変更（※確認はまだ）
> > 
> > 初期設定ダイアログの「後で」を削除。
> > 
> > 初期設定ダイアログの文章レイアウトをある程度改善。
> > 
> > 備蓄品メーター上の「防災グッズ」を「備蓄品」に変更。
> 
> 発見したバグ。
> 
> > 非常食、備蓄品の～未満のダイアログにて、
> > 備蓄品を「確認する」にして、ホームに戻ると、
> > 非常食ダイアログが2回連続で出るバグを発見。
